### PR TITLE
feat: allow configuring config path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
     description: 'Max execution time in seconds'
     required: false
     default: '1200'
+  configPath:
+    description: 'Path to Redocly config file'
+    required: false
   githubToken:
     description: 'Token to authenticate with'
     required: true

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,6 +13,7 @@ export function parseInputData(): ParsedInputData {
   const redoclyDomain =
     core.getInput('domain') || 'https://app.cloud.redocly.com';
   const maxExecutionTime = Number(core.getInput('maxExecutionTime')) || 1200;
+  const configPath = core.getInput('configPath') || undefined;
 
   const absoluteFilePaths = files.map(_path =>
     path.join(process.env.GITHUB_WORKSPACE || '', _path),
@@ -25,6 +26,7 @@ export function parseInputData(): ParsedInputData {
     files: absoluteFilePaths,
     redoclyDomain,
     maxExecutionTime,
+    configPath,
   };
 }
 
@@ -124,9 +126,13 @@ function getCommitSha(): string | undefined {
   }
 }
 
-// Returns parsed config from the root or default config if not found
-export async function getRedoclyConfig(): ReturnType<typeof loadConfig> {
-  const redoclyConfig = await loadConfig();
+// Returns parsed config from the specified path or default config if not found
+export async function getRedoclyConfig(
+  configPath?: string,
+): ReturnType<typeof loadConfig> {
+  const redoclyConfig = await loadConfig(
+    configPath ? { configPath } : undefined,
+  );
 
   return redoclyConfig;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ export async function run(): Promise<void> {
     console.debug('Parsed input data', inputData);
     console.debug('Parsed GitHub event', ghEvent);
 
-    const config = await getRedoclyConfig();
+    const config = await getRedoclyConfig(inputData.configPath);
 
     const pushData = await handlePush({
       argv: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface ParsedInputData {
   files: string[];
   mountPath: string;
   maxExecutionTime: number;
+  configPath?: string;
 }
 
 export interface ParsedEventData {


### PR DESCRIPTION
## What/Why/How?

  **What:** Added optional `configPath` input parameter to allow specifying custom path to Redocly configuration file.

  **Why:** Currently this action assumes that the Redocly configuration lives in the root of wherever it is being run. That might not always be the case, thus I'm adding this option to be able to set where the config lives.

  **How:** Extended the action inputs, updated parsing logic to handle the new parameter, and modified `getRedoclyConfig()` to pass the custom  path to `loadConfig()` from `@redocly/openapi-core`.

  ## Reference

  - Uses existing `loadConfig({ configPath })` API from `@redocly/openapi-core`
  - Maintains backward compatibility - when no `config` parameter is provided, uses default discovery behavior

  ## Testing

  - Added unit tests for `parseInputData()` with and without custom config parameter
  - Added unit tests for `getRedoclyConfig()` with default and custom config paths
  - Mocked `loadConfig` to avoid file system dependencies in tests
  - All existing tests continue to pass
  - Linting and formatting checks pass

  ## Screenshots / Video (optional)

  N/A

  ## Additional context

  Usage example:
  ```yaml
  - uses: your-action
    with:
      organization: your-org
      project: your-project
      configPath: 'configs/custom-redocly.yaml'  # Optional - new parameter
      files: 'docs/'
      mountPath: '/docs'